### PR TITLE
Add `--llm-api-endpoint` to allow non-standard OpenAI endpoints

### DIFF
--- a/src/pullhero/__about__.py
+++ b/src/pullhero/__about__.py
@@ -1,3 +1,3 @@
 __name__ = "pullhero"
 __description__ = "pullhero CLI"
-__version__ = "0.0.9"
+__version__ = "0.0.10"

--- a/src/pullhero/agents/code.py
+++ b/src/pullhero/agents/code.py
@@ -44,6 +44,7 @@ def action_code(
     llm_api_key: str,
     llm_api_host: str,
     llm_api_model: str,
+    llm_api_endpoint: str,
 ) -> None:
 
     logging.info(f"Starting code action for {vcs_repository} PR/MR {vcs_change_id}")
@@ -197,7 +198,7 @@ Your entire response must be ONLY the improved code file, with no preamble, expl
             logging.info("Sending prompt to AI API to generate improved code...")
             try:
                 new_content = call_ai_api(
-                    llm_api_host, llm_api_key, llm_api_model, prompt
+                    llm_api_host, llm_api_key, llm_api_model, llm_api_endpoint, prompt
                 )
             except Exception as e:
                 logging.error("AI API call failed: %s", e)

--- a/src/pullhero/agents/consult.py
+++ b/src/pullhero/agents/consult.py
@@ -43,6 +43,7 @@ def action_consult(
     llm_api_key: str,
     llm_api_host: str,
     llm_api_model: str,
+    llm_api_endpoint: str,
 ) -> None:
 
     label_to_parse = "consult"
@@ -95,7 +96,7 @@ def action_consult(
             logging.info(f"Calling AI API ({llm_api_model}) for review generation")
             try:
                 consult_result = call_ai_api(
-                    llm_api_host, llm_api_key, llm_api_model, prompt
+                    llm_api_host, llm_api_key, llm_api_model, llm_api_endpoint, prompt
                 )
                 provider.post_comment(
                     vcs_repository, str(issue["number"]), consult_result, "issue"

--- a/src/pullhero/agents/document.py
+++ b/src/pullhero/agents/document.py
@@ -45,6 +45,7 @@ def action_document(
     llm_api_key: str,
     llm_api_host: str,
     llm_api_model: str,
+    llm_api_endpoint: str,
 ) -> None:
 
     logging.info(f"Starting document action for {vcs_repository} PR/MR {vcs_change_id}")
@@ -90,7 +91,7 @@ def action_document(
 
         logging.info(f"Calling AI API ({llm_api_model}) for review generation")
         try:
-            new_readme = call_ai_api(llm_api_host, llm_api_key, llm_api_model, prompt)
+            new_readme = call_ai_api(llm_api_host, llm_api_key, llm_api_model, llm_api_endpoint, prompt)
         except Exception as e:
             logging.error("AI API call failed: %s", e)
             sys.exit(1)

--- a/src/pullhero/agents/review.py
+++ b/src/pullhero/agents/review.py
@@ -41,6 +41,7 @@ def action_review(
     llm_api_key: str,
     llm_api_host: str,
     llm_api_model: str,
+    llm_api_endpoint: str,
 ) -> None:
     """
     Perform a code review action on a VCS pull/merge request using an LLM-powered agent.
@@ -130,6 +131,7 @@ def action_review(
             llm_api_key=llm_api_key,
             llm_api_host=llm_api_host,
             llm_api_model=llm_api_model,
+            llm_api_endpoint=llm_api_endpoint,
         )
 
         # Determine review vote
@@ -200,6 +202,7 @@ def get_review(
     llm_api_key: str,
     llm_api_host: str,
     llm_api_model: str,
+    llm_api_endpoint: str,
 ) -> str:
     """
     Retrieves an AI-generated code review for a given pull/merge request.
@@ -294,7 +297,7 @@ def get_review(
         logging.debug(f"Prompt generated with {len(prompt.splitlines())} lines")
 
         logging.info(f"Calling AI API ({llm_api_model}) for review generation")
-        review_text = call_ai_api(llm_api_host, llm_api_key, llm_api_model, prompt)
+        review_text = call_ai_api(llm_api_host, llm_api_key, llm_api_model, llm_api_endpoint, prompt)
         logging.info("AI review generation completed successfully")
 
         return review_text

--- a/src/pullhero/pullhero.py
+++ b/src/pullhero/pullhero.py
@@ -164,6 +164,11 @@ def main():
         default=os.environ.get("LLM_API_MODEL", "gpt-4o-mini"),
         help="LLM Model, e.g., gpt-4o-mini",
     )
+    parser.add_argument(
+        "--llm-api-endpoint",
+        default=os.environ.get("LLM_API_ENDPOINT", "/v1/chat/completions"),
+        help="LLM API Endpoint, default: /v1/chat/completions",
+    )
 
     args = parser.parse_args()
 
@@ -180,6 +185,7 @@ def main():
         "llm_api_key": args.llm_api_key,
         "llm_api_host": args.llm_api_host,
         "llm_api_model": args.llm_api_model,
+        "llm_api_endpoint": args.llm_api_endpoint,
     }
 
     logging.info(f"PullHero v{__version__}")

--- a/src/pullhero/utils/misc.py
+++ b/src/pullhero/utils/misc.py
@@ -314,6 +314,7 @@ def call_ai_api(
         response.raise_for_status()
 
         data = response.json()
+        logger.debug(f"Response: {data}")
         result = data["choices"][0]["message"]["content"]
 
         logger.info("AI API call successful")
@@ -325,7 +326,7 @@ def call_ai_api(
         logger.error(
             f"API request failed: {he.response.status_code} - {he.response.text}"
         )
-        raise
+        raise he
     except requests.Timeout:
         logger.error("API request timed out")
         raise

--- a/src/pullhero/utils/misc.py
+++ b/src/pullhero/utils/misc.py
@@ -231,7 +231,7 @@ def ingest_repository(local_repo_path: str) -> Tuple[str, str, str]:
 
 
 def call_ai_api(
-    api_host: str, api_key: str, api_model: str, prompt: str, timeout: int = 360
+    api_host: str, api_key: str, api_model: str, api_endpoint: str, prompt: str, timeout: int = 360
 ) -> str:
     """
     Make an API call to an AI service for code review analysis.
@@ -282,7 +282,7 @@ def call_ai_api(
             logger.error(error_msg)
             raise ValueError(error_msg)
 
-        url = f"https://{api_host}/v1/chat/completions"
+        url = f"https://{api_host}{api_endpoint}"
         payload = {
             "model": api_model,
             "messages": [{"role": "user", "content": prompt}],


### PR DESCRIPTION
This PR adds the `--llm-api-endpoint` argument to allow for nonstandard OpenAI endpoints.  This will allow models like Gemini to work with pullhero.

The default for `--llm-api-endpoint` is `/v1/chat/completions`, which is standard and will not require users to update their scripts/workflows to continue working.

This should resolve #15 