### PR TITLE
Fix: Install gitingest server group to fix install issues

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,4 @@
-gitingest>=0.1.3
+gitingest[server]>=0.1.3
 # GNU GENERAL PUBLIC LICENSE
 # Version 3, 29 June 2007
 #


### PR DESCRIPTION
This PR installs the gitingest server group to fix runtime issues after installing (namely `fastapi` missing).

This should resolve #17 